### PR TITLE
WIP: import components as modules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,13 +14,13 @@ PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "1.1"
 DataStructures = "0.17.5"
 HTTP = "0.8.6"
 JSON = "0.21.0"
 JSON2 = "0.3.1"
 MacroTools = "0.5.1"
 PlotlyBase = "0.3.0"
+julia = "1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/components_meta.json
+++ b/components_meta.json
@@ -1,6 +1,6 @@
 [
     {
-        "name" : "renderer",
+        "name" : "Renderer",
         "package_name" : "dash_renderer",
         "source_path" : "/lib/dash/dash-renderer/dash_renderer/",
         "scripts" : {
@@ -20,7 +20,7 @@
         "has_components" : false
     },
     {
-        "name" : "dcc",
+        "name" : "DCC",
         "package_name" : "dash_core_components",
         "source_path" : "/components/dash-core-components/dash_core_components/",
         "scripts" : {
@@ -38,7 +38,7 @@
         "has_components" : true
     },
     {
-        "name" : "html",
+        "name" : "HTML",
         "package_name" : "dash_html_components",
         "source_path" : "/components/dash-html-components/dash_html_components/",
         "scripts" : {
@@ -48,7 +48,7 @@
         "has_components" : true
     },
     {
-        "name" : "dbc",
+        "name" : "DBC",
         "package_name" : "dash_bootstrap_components/_components",
         "source_path" : "/components/dash-bootstrap-components/dash_bootstrap_components/_components/",
         "scripts" : {


### PR DESCRIPTION
Here's the sketch of how to use modules like `DCC.checkbox` instead of `dcc_checkbox` — if so desired.

Still needs docs updates, etc.