### PR TITLE
Enable integration tests with Dash.jl and add server startup message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,12 @@ version: 2
 jobs:
 
   test:
-    working_directory: /root/project/Dash
-
+    working_directory: ~/dashjl 
     docker:
-      - image: julia:latest 
+      - image: plotly/julia:ci 
+        environment:
+          PERCY_PARALLEL_TOTAL: '-1'
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'True'
 
     steps:
       - checkout
@@ -26,7 +28,28 @@ jobs:
       - run:
           name: 🔎 Unit tests
           command: |
-              julia -e 'using Pkg; Pkg.update(); Pkg.add(PackageSpec(path=pwd())); Pkg.build("Dash"); Pkg.test("Dash", coverage=true);'
+            julia -e 'using Pkg; Pkg.update(); Pkg.add(PackageSpec(url="https://github.com/plotly/Dash.jl.git", rev="enable-integration")); Pkg.add(PackageSpec(url="https://github.com/waralex/dash-html-components.git", rev="jl_generator_test")); Pkg.add(PackageSpec(url="https://github.com/waralex/dash-core-components.git", rev="jl_generator_test")); Pkg.build("Dash"); Pkg.build("DashHtmlComponents"); Pkg.build("DashCoreComponents"); Pkg.test("Dash", coverage=true);'
+
+      - run:
+          name: ⚙️  Integration tests
+          command: |
+            python -m venv venv
+            . venv/bin/activate
+            git clone --depth 1 https://github.com/plotly/dash.git -b add-julia-runner dash-main
+            cd dash-main && pip install -e .[dev,testing] --progress-bar off && cd ~/dashjl 
+            export PATH=$PATH:/home/circleci/.local/bin/
+            pytest -v --log-cli-level DEBUG --nopercyfinalize --junitxml=test-reports/dashjl.xml --percy-assets=test/assets/ test/integration/
+      - store_artifacts:
+          path: test-reports
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: /tmp/dash_artifacts
+
+      - run:
+          name: 🦔 percy finalize
+          command: npx percy finalize --all
+          when: always
 
 workflows:
   version: 2

--- a/src/Dash.jl
+++ b/src/Dash.jl
@@ -112,7 +112,7 @@ function run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8050;
         dev_tools_prune_errors = dev_tools_prune_errors
     )
     handler = make_handler(app);
-    @info "started"
+    @info string("Running on http://", host, ":", port)
     HTTP.serve(handler, host, port)
 end
 

--- a/src/Dash.jl
+++ b/src/Dash.jl
@@ -57,14 +57,14 @@ callback!(app, callid"graphTitle.value => graph.figure") do value
     )
 end
 handle = make_handler(app, debug = true)
-run_server(handle, HTTP.Sockets.localhost, 8080)
+run_server(handle, HTTP.Sockets.localhost, 8050)
 ```
 
 """ Dashboards
 
 
 """
-    run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8080; debug::Bool = false)
+    run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8050; debug::Bool = false)
 
 Run Dash server
 
@@ -82,11 +82,11 @@ julia> app = dash("Test") do
     end
 end
 julia>
-julia> run_server(handler,  HTTP.Sockets.localhost, 8080)
+julia> run_server(handler,  HTTP.Sockets.localhost, 8050)
 ```
 
 """
-function run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8080;
+function run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8050;
             debug = nothing, 
             dev_tools_ui = nothing,
             dev_tools_props_check = nothing,

--- a/test/integration/test_sample_app.py
+++ b/test/integration/test_sample_app.py
@@ -1,0 +1,20 @@
+app = '''
+using Dash
+using DashHtmlComponents
+
+println("00000")
+app = dash("Test app")
+
+app.layout = html_div() do
+ html_div("Hello Dash.jl testing", id="container")
+end
+
+println("111")
+run_server(app, "127.0.0.1", 8050)
+'''
+
+def test_jstr001_jl_with_string(dashjl, start_timeout=20):
+    dashjl.start_server(app)
+    dashjl.wait_for_text_to_equal(
+        "#container", "Hello Dash.jl testing", timeout=10
+    )

--- a/test/integration/test_sample_app.py
+++ b/test/integration/test_sample_app.py
@@ -2,18 +2,16 @@ app = '''
 using Dash
 using DashHtmlComponents
 
-println("00000")
 app = dash("Test app")
 
 app.layout = html_div() do
  html_div("Hello Dash.jl testing", id="container")
 end
 
-println("111")
-run_server(app, "127.0.0.1", 8050)
+run_server(app)
 '''
 
-def test_jstr001_jl_with_string(dashjl, start_timeout=20):
+def test_jstr001_jl_with_string(dashjl):
     dashjl.start_server(app)
     dashjl.wait_for_text_to_equal(
         "#container", "Hello Dash.jl testing", timeout=10


### PR DESCRIPTION
This PR proposes to add integration test support in `plotly/Dash.jl`, based on work performed in plotly/dash#1239. When that PR merges into `dev` of the `plotly/dash` repo, we'll need to modify the CircleCI configuration to use that branch instead.

A simple example test is included. Future tests should follow the same general structure and be placed into `test/integration`, and subdirectories may be used to help group similar tests (e.g. `callbacks`, `devtools`, `clientside`).

The default host remains `127.0.0.1` but the default port is changed to `8050`, which matches Dash for R and Python.

A minor modification to `src/Dash.jl` is also proposed which adds a basic startup message at HTTP.jl launch time:

```
julia> run_server(app)
[ Info: Running on http://127.0.0.1:8050
```