### PR TITLE
core components install prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/build
 venv
 *.pyc
 tmp
+core_components/sources

--- a/core_components/versions.jl
+++ b/core_components/versions.jl
@@ -1,0 +1,17 @@
+const COMPONENT_VERSIONS = (
+    DashHtmlComponents = (
+        version = "1.0.1",
+        url = "https://github.com/plotly/dash-html-components.git",
+        rev = "jl"
+    ),
+    DashCoreComponents = (
+        version = "1.4.0",
+        url = "https://github.com/plotly/dash-core-components.git",
+        rev = "jl"
+    ),
+    DashTable = (
+        version = "4.7.0",
+        url = "https://github.com/plotly/dash-table.git",
+        rev = "jl"
+    ),
+)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,23 @@
+import LibGit2
+const ROOT_PATH = abspath(joinpath(@__DIR__, ".."))
+const CORE_COMPONENTS_PATH = joinpath(ROOT_PATH, "core_components")
+const CORE_COMPONENTS_SRCS = joinpath(CORE_COMPONENTS_PATH, "sources")
+
+(isdir(CORE_COMPONENTS_SRCS) && !isempty(readdir(CORE_COMPONENTS_SRCS))) && exit(0)
+
+include(joinpath(CORE_COMPONENTS_PATH, "versions.jl"))
+
+include("git.jl")
+include("files.jl")
+
+
+mktempdir() do temp_path
+    for pkg_name in keys(COMPONENT_VERSIONS)
+        pkg = COMPONENT_VERSIONS[pkg_name]
+        pkg_string = string(pkg_name)
+        clone_path = joinpath(temp_path, pkg_string)
+        repo = clone(pkg.url, clone_path)
+        checkout!(repo::LibGit2.GitRepo, pkg.rev)
+        copy_components_sources(clone_path, pkg_string)
+    end
+end

--- a/deps/files.jl
+++ b/deps/files.jl
@@ -1,0 +1,32 @@
+function fix_import(src_file, dest_file)
+    source = replace(String(read(src_file)),
+        "using Dash"=>"using ..Dash"
+        )
+
+    source = replace(source, "function __init__()" => "function __dash_init__()")
+    write(dest_file, source)
+end 
+
+function copy_components_sources(repo_path, package_name)
+    package_path = joinpath(CORE_COMPONENTS_SRCS, package_name)
+    package_src_path = joinpath(package_path, "src")
+    package_deps_path = joinpath(package_path, "deps")
+
+    main_file = package_name * ".jl"
+
+    rm(package_path, force=true, recursive=true)
+
+    mkpath(package_src_path)
+    mkpath(package_deps_path)
+
+    for file in readdir(joinpath(repo_path, "src"))
+        if file == main_file
+            fix_import(joinpath(repo_path, "src", file), joinpath(package_src_path, file))
+            continue
+        end
+        if endswith(file, ".jl")
+            cp(joinpath(repo_path, "src", file), joinpath(package_src_path, file), force=true)
+        end
+    end
+    cp(joinpath(repo_path, "deps"), package_deps_path, force=true)
+end

--- a/deps/git.jl
+++ b/deps/git.jl
@@ -1,0 +1,51 @@
+function clone(url::String, source_path::String)
+    println(stdout, "cloning $(url)...")
+    mkpath(source_path)
+    try
+        return LibGit2.clone(url, source_path)
+    catch err
+        rm(source_path; force=true, recursive=true)
+        err isa LibGit2.GitError || err isa InterruptException || rethrow()
+        if err isa InterruptException
+            error("git clone of `$url` interrupted")
+        elseif (err.class == LibGit2.Error.Net && err.code == LibGit2.Error.EINVALIDSPEC) ||
+           (err.class == LibGit2.Error.Repository && err.code == LibGit2.Error.ENOTFOUND)
+                error("git repository not found at `$(url)`")
+        else
+            error("failed to clone from $(url), error: $err")
+        end
+    end
+end
+
+function get_object_branch(repo, rev)
+    gitobject = nothing
+    isbranch = false
+    LibGit2.fetch(repo, refspecs = ["+refs/*:refs/remotes/cache/*"])
+    try
+        gitobject = LibGit2.GitObject(repo, "remotes/cache/heads/" * rev)
+        isbranch = true
+    catch err
+        err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
+    end
+    if isnothing(gitobject)
+        try
+            gitobject = LibGit2.GitObject(repo, rev)
+        catch err
+            err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow()
+            error("git object $(rev) could not be found")
+        end
+    end
+    return gitobject, isbranch
+end
+
+function checkout!(repo::LibGit2.GitRepo, rev::String)
+    gitobject, isbranch = get_object_branch(repo, rev)
+
+    LibGit2.with(LibGit2.peel(LibGit2.GitTree, gitobject)) do git_tree
+        @assert git_tree isa LibGit2.GitTree
+        opts = LibGit2.CheckoutOptions(
+            checkout_strategy = LibGit2.Consts.CHECKOUT_FORCE,
+        )
+        LibGit2.checkout_tree(repo, git_tree)
+    end
+end

--- a/src/Dash.jl
+++ b/src/Dash.jl
@@ -10,17 +10,35 @@ using .Components
 
 export dash, Component, Front, <|, @callid_str, CallbackId, callback!,
 enable_dev_tools!, ClientsideFunction,
-run_server, PreventUpdate, no_update, @var_str
+run_server, PreventUpdate, no_update, @var_str, @using_components
 
 
 
-#ComponentPackages.@reg_components()
 include("env.jl")
 include("utils.jl")
 include("app.jl")
 include("resources/registry.jl")
 include("resources/application.jl")
 include("handlers.jl")
+include("core_components.jl")
+
+"""
+    @using_components(package_name)
+
+Load the components module or package and make its functions available for direct use. 
+It also adds package resources to the list of resources required for the dashboard
+"""
+macro using_components(name::Symbol)
+    
+    result = Expr(:toplevel)
+    if name in (:DashHtmlComponents, :DashCoreComponents, :DashTable) 
+        push!(result.args, esc(:(using Dash.$name)))
+        push!(result.args, esc(:(Dash.$name.__dash_init__();)))
+    else
+        push!(result.args, esc(:(using $name)))
+    end
+    return result
+end
 
 @doc """
     module Dash

--- a/src/core_components.jl
+++ b/src/core_components.jl
@@ -1,0 +1,6 @@
+export DashHtmlComponents
+export DashCoreComponents
+export DashTable
+include("../core_components/sources/DashHtmlComponents/src/DashHtmlComponents.jl")
+include("../core_components/sources/DashCoreComponents/src/DashCoreComponents.jl")
+include("../core_components/sources/DashTable/src/DashTable.jl")


### PR DESCRIPTION
This is an experiment with installing components as part of Dash.
This works as follows. When installing / updating `Dash` (or manually calling `Pkg.build("Dash")`) `Dash` checks whether there is content in the `core_components/sources` folder, and if there is nothing there, then git clone of component repos to the temporary directory is executed. After that, only the files necessary for working with the Julia version of components are copied from the repositories to the `core_components/sources` of the Dash package. The location and revision of components repos are set in the file `core_components/versions.jl`. 
Accordingly, in the `dev` version, when `core_components/sources` is added to `.gitignore`, components will be downloaded every time `Dash` is installed, which allows us not to store a copy of the components in the repository all the time. If we remove `core_components/sources` from `.gitignore` in the release, the components will be installed together with `Dash` without having to wait for cloning large repositories with js and Python code.

Dash include these components as a submodules:
```
export DashHtmlComponents
export DashCoreComponents
export DashTable
include("../core_components/sources/DashHtmlComponents/src/DashHtmlComponents.jl")
include("../core_components/sources/DashCoreComponents/src/DashCoreComponents.jl")
include("../core_components/sources/DashTable/src/DashTable.jl")
```

And here lies the main pitfall of this variant. The module's `__init__ ()` function (which adds component data resources to the Dash resource registry in our case) is called only once after the module code is fully loaded. So in this case, it will be called at the `include("....")` moment inside `Dash`, not when the user does `using Dash.DashHtmlComponents`, as I expected.
As a workaround, I renamed `__init__` for the core components to `__dash_init__` . And wrote the `@using_components` macro. This macro is arranged as follows: if one of the core component packages is passed to it (`@using_components DashHtmlComponents`), it turns into this code at compile time:
```
using Dash.DashHtmlComponents
Dash.DashHtmlComponents.__dash_init__()
```
For all other packages it just substitutes `using` instead of itself.

In other words, it can be used for uniform connection of both core components and any other components:
```
using Dash
@using_components DashHtmlComponents #i.e. using Dash.DashHtmlComponents; Dash.DashHtmlComponents.__dash_init__()
@using_components DashTable #i.e. using Dash.DashTable; Dash.DashTable.__dash_init__()
@using_components ExternalComponents #i.e using ExternalComponents
```

This workaround requires discussion and has both pros and cons. On the one hand, this allows users to use both internal and external packages in the same way. Give us suitable way of initialization of resources, etc. In addition, the presence of side effects (adding resources to the application page) is more obvious in the case of a special call than in the case of normal `using`. On the other hand it is a user experience that differs from similar experiences in Python and R.

The whole approach with the core components were installed as part of the Dash also needs to be discussed