### PR TITLE
The passing the exceptions to the front end in debug mode

### DIFF
--- a/src/HttpHelpers/HttpHelpers.jl
+++ b/src/HttpHelpers/HttpHelpers.jl
@@ -1,6 +1,6 @@
 module HttpHelpers
 
-export state_handler, compress_handler, Route, Router, add_route!
+export state_handler, exception_handling_handler, compress_handler, Route, Router, add_route!
 
 import HTTP, CodecZlib
 

--- a/src/HttpHelpers/handlers.jl
+++ b/src/HttpHelpers/handlers.jl
@@ -47,14 +47,15 @@ function exception_handling_handler(ex_handling_func, base_handler)
             try
                 return HTTP.handle(base_handler, request, args...)
             catch e
-                return ex_handlig_func(e)
+                return ex_handling_func(e)
             end
 
         end
     )
 end
 
-exception_handling_handler(ex_handlig_func, base_handler::Function) = exception_handling_handler(HTTP.RequestHandlerFunction(base_handler), state)
+exception_handling_handler(ex_handling_func, base_handler::Function) =
+         exception_handling_handler(ex_handling_func, HTTP.RequestHandlerFunction(base_handler))
 
 function request_logging_handler(base_handler; exclude = Regex[])
     return HTTP.RequestHandlerFunction(

--- a/src/handler/make_handler.jl
+++ b/src/handler/make_handler.jl
@@ -23,9 +23,9 @@ function start_reload_poll(state::HandlerState)
                     replace(relpath(file, assets_path), '\\'=>'/'),
                     '/'
                 )
-            push!(state.reload.changed_assets, 
+            push!(state.reload.changed_assets,
                 ChangedAsset(
-                    asset_path(state.app, rel_path), 
+                    asset_path(state.app, rel_path),
                     trunc(Int, ts),
                     endswith(file, "css")
                     )
@@ -40,14 +40,83 @@ validate_layout(layout::Component) = validate(layout)
 validate_layout(layout::Function) = validate_layout(layout())
 
 validate_layout(layout) = error("The layout must be a component, tree of components, or a function which returns a component.")
+
+function stack_from_callback(full_stack)
+    result = Base.StackTraces.StackFrame[]
+    it = iterate(full_stack)
+    while !isnothing(it) && it[1].func != :process_callback_call
+        push!(result, it[1])
+        it = iterate(full_stack, it[2])
+    end
+    return result
+end
+
+
+function exception_handling(ex)
+    st = stack_from_callback(stacktrace(catch_backtrace()))
+    @error exception = (ex, st)
+    return HTTP.Response(500)
+end
+
+#<!DOCTYPE HTML><html><body><pre><h3>%s</h3><br>Error: %s: %s<br>%s</pre></body></html>
+# ### DashR Traceback (most recent/innermost call last) ###
+function debug_exception_handling(ex)
+    response = HTTP.Response(500, ["Content-Type" => "text/html"])
+    io = IOBuffer()
+    write(io,
+         "<!DOCTYPE HTML><html>",
+         "<head>",
+         "<style type=\"text/css\">",
+         """
+            div.debugger { text-align: left; padding: 12px; margin: auto;
+            background-color: white; }
+            h1           { font-size: 36px; margin: 0 0 0.3em 0; }
+            div.detail { cursor: pointer; }
+            div.detail p { margin: 0 0 8px 13px; font-size: 14px; white-space: pre-wrap;
+            font-family: monospace; }
+            div.plain { border: 1px solid #ddd; margin: 0 0 1em 0; padding: 10px; }
+            div.plain p      { margin: 0; }
+            div.plain textarea,
+            div.plain pre { margin: 10px 0 0 0; padding: 4px;
+                background-color: #E8EFF0; border: 1px solid #D3E7E9; }
+            div.plain textarea { width: 99%; height: 300px; }
+            """,
+         "</style>",
+         "</head>",
+         "<body style=\"background-color: #fff\">",
+         "<div class=\"debugger\">",
+         "<div class=\"detail\">",
+         "<p class=\"errormsg\">")
+    showerror(io, ex)
+    write(io,
+        "</p>",
+        "</div>",
+        "</div>",
+        "<div class=\"plain\">",
+        "<textarea cols=\"50\" rows=\"10\" name=\"code\" readonly>"
+    )
+    st = stack_from_callback(stacktrace(catch_backtrace()))
+    Base.show_backtrace(io, st)
+
+    write(io, "</textarea>")
+
+    write(io, "</body></html>")
+
+    response.body = take!(io)
+
+    @error exception = (ex, st)
+
+    return response
+end
+
 #For test purposes, with the ability to pass a custom registry
 function make_handler(app::DashApp, registry::ResourcesRegistry; check_layout = false)
-            
+
     state = HandlerState(app, registry)
     prefix = get_setting(app, :routes_pathname_prefix)
     assets_url_path = get_setting(app, :assets_url_path)
     check_layout && validate_layout(get_layout(app))
-    
+
     router = Router()
     add_route!(process_layout, router, "$(prefix)_dash-layout")
     add_route!(process_dependencies, router, "$(prefix)_dash-dependencies")
@@ -59,6 +128,11 @@ function make_handler(app::DashApp, registry::ResourcesRegistry; check_layout = 
     add_route!(process_index, router, "$prefix")
 
     handler = state_handler(router, state)
+    if get_devsetting(app, :prune_errors)
+        handler = exception_handling_handler(debug_exception_handling, handler)
+    else
+        handler = exception_handling_handler(exception_handling, handler)
+    end
     get_setting(app, :compress) && (handler = compress_handler(handler))
 
     compile_request = HTTP.Request("GET", prefix)

--- a/src/handler/processors/callback.jl
+++ b/src/handler/processors/callback.jl
@@ -49,7 +49,6 @@ outputs_to_vector(out::Vector) = out
 outputs_to_vector(out) = [out]
 
 function process_callback(request::HTTP.Request, state::HandlerState)
-    println(request.headers)
     app = state.app
     response = HTTP.Response(200, ["Content-Type" => "application/json"])
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -23,7 +23,7 @@ julia> run_server(handler,  HTTP.Sockets.localhost, 8050)
 
 """
 function run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8050;
-            debug = nothing, 
+            debug = nothing,
             dev_tools_ui = nothing,
             dev_tools_props_check = nothing,
             dev_tools_serve_dev_bundles = nothing,
@@ -35,7 +35,7 @@ function run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8050;
             dev_tools_prune_errors = nothing
             )
     @env_default!(debug, Bool, false)
-    enable_dev_tools!(app, 
+    enable_dev_tools!(app,
         debug = debug,
         dev_tools_ui = dev_tools_ui,
         dev_tools_props_check = dev_tools_props_check,
@@ -47,26 +47,11 @@ function run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8050;
         dev_tools_silence_routes_logging = dev_tools_silence_routes_logging,
         dev_tools_prune_errors = dev_tools_prune_errors
     )
-    main_func = () -> begin
-        ccall(:jl_exit_on_sigint, Cvoid, (Cint,), 0)
-        handler = make_handler(app);
-        try
-            task = @async HTTP.serve(handler, host, port)
-            @info string("Running on http://", host, ":", port)
-            wait(task)
-        catch e
-            if e isa InterruptException
-                @info "exited"
-            else
-                rethrow(e)
-            end
 
-        end
-    end
     start_server = () -> begin
         handler = make_handler(app);
         server = Sockets.listen(get_inetaddr(host, port))
-        task = @async HTTP.serve(handler, host, port; server = server)
+        task = @async HTTP.serve(handler, host, port; server = server, verbose = true)
         @info string("Running on http://", host, ":", port)
         return (server, task)
     end
@@ -84,7 +69,7 @@ function run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8050;
             println(task)
         catch e
             close(server)
-            if e isa InterruptException 
+            if e isa InterruptException
                 println("finished")
                 return
             else

--- a/src/server.jl
+++ b/src/server.jl
@@ -52,7 +52,6 @@ function run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8050;
         handler = make_handler(app);
         server = Sockets.listen(get_inetaddr(host, port))
         task = @async HTTP.serve(handler, host, port; server = server, verbose = true)
-        @info string("Running on http://", host, ":", port)
         return (server, task)
     end
 
@@ -66,7 +65,6 @@ function run_server(app::DashApp, host = HTTP.Sockets.localhost, port = 8050;
         (server, task) = start_server()
         try
             wait(task)
-            println(task)
         catch e
             close(server)
             if e isa InterruptException

--- a/test/integration/callbacks/jl_test_wildcards/todo_app.jl
+++ b/test/integration/callbacks/jl_test_wildcards/todo_app.jl
@@ -41,14 +41,14 @@ function todo_app(content_callback)
         triggered = [t.prop_id for t in callback_context().triggered]
         adding = any((id)->id in ("add.n_clicks", "new-item.n_submit"), triggered)
         clearing = any((id)->id == "clear-done.n_clicks", triggered)
-        
+
         new_spec = Vector{Any}()
 
         push!.(Ref(new_spec),
             Iterators.filter(zip(items, items_done)) do (text, done)
                 return !(clearing && !isempty(done))
             end
-        ) 
+        )
 
         adding && push!(new_spec, (new_item, []))
         new_list = [
@@ -78,10 +78,10 @@ function todo_app(content_callback)
     end
 
     callback!(app,
-        Output((item = MATCH, preceding = true), "children"),        
+        Output((item = MATCH, preceding = true), "children"),
         Input((item = ALLSMALLER, action = "done"), "value"),
         Input((item = MATCH, action = "done"), "value"),
-        
+
     ) do done_before, this_done
         !isempty(this_done) && return ""
         all_before = length(done_before)
@@ -93,15 +93,15 @@ function todo_app(content_callback)
 
     callback!(app,
         Output("totals", "children"), Input((item = ALL, action = "done"), "value")
-    ) do done        
+    ) do done
         count_all = length(done)
         count_done = count((d)->!isempty(d), done)
         result = "$(count_done) of $(count_all) items completed"
-        (count_all > 0) && (result *= " - $(floor(Int, 100 * count_done / count_all))%")            
-        
+        (count_all > 0) && (result *= " - $(floor(Int, 100 * count_done / count_all))%")
+
         return result
     end
-    
+
     return app
-   
+
 end


### PR DESCRIPTION
In debug mode, exceptions are passed to the web interface. If an exception occurred inside the callback, the backtrace contains only elements after entering the callback.
For visual design, I partially used the styles that are used in the Python version.
<img width="602" alt="Снимок экрана 2020-08-06 в 10 33 10" src="https://user-images.githubusercontent.com/4685438/89513248-fd429e80-d7dc-11ea-9193-41fb0f4c01eb.png">
