### PR TITLE
Fix for PlotlyJS  Plot vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dash"
 uuid = "1b08a953-4be3-4667-9a23-3db579824955"
 authors = ["Chris Parmer <chris@plotly.com>", "Alexandr Romanenko <waralex@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/src/handler/processors/callback.jl
+++ b/src/handler/processors/callback.jl
@@ -27,12 +27,12 @@ function _push_to_res!(res, value, out)
         )
 end
 
+_single_element_vect(e::T) where {T} = T[e]
 function process_callback_call(app, callback_id, outputs, inputs, state)
     cb = app.callbacks[callback_id]
     res = cb.func(make_args(inputs, state)...)
     (res isa NoUpdate) && throw(PreventUpdate())
-    res_vector = is_multi_out(cb) ? res : [res]
-
+    res_vector = is_multi_out(cb) ? res : _single_element_vect(res)
     validate_callback_return(outputs, res_vector, callback_id)
 
     response = Dict{String, Any}()


### PR DESCRIPTION
It turned out that `PlotlyJs.jl` implemented an ugly architectural solution. Redefined the `vect(items::T...)` method that is called for the `[items...]` syntax, and it returns not an array, but the `Plot` structure, to which the call elements are added as sub-graphs. Accordingly, I corrected the creation of an array from a single element when returning from a callback, so that it always creates an array bypassing the `vect` call