### PR TITLE
Fix callback with multiple output referencing some component id

### DIFF
--- a/src/handler/processors/callback.jl
+++ b/src/handler/processors/callback.jl
@@ -20,11 +20,16 @@ function _push_to_res!(res, value, out::Vector)
     _push_to_res!.(Ref(res), value, out)
 end
 function _push_to_res!(res, value, out)
-    !(value isa NoUpdate) && push!(res,
-            dep_id_string(out.id) => Dict(
-                Symbol(out.property) => DashBase.to_dash(value)
-            )
-        )
+    if !(value isa NoUpdate)
+        id = dep_id_string(out.id)
+        prop = Symbol(out.property)
+        dashval = DashBase.to_dash(value)
+        if haskey(res, id)
+            push!(res[id], prop => dashval)
+        else
+            push!(res, id => Dict{Symbol, Any}(prop => dashval))
+        end
+    end
 end
 
 _single_element_vect(e::T) where {T} = T[e]

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -121,6 +121,31 @@ end
     @test app.callbacks[Symbol("my-div.children")].func("value", " value2") == "value value2"
 
 end
+@testset "callback! multi output same component id" begin
+    app = dash()
+    app.layout = html_div() do
+            dcc_input(id = "input-one",
+                      placeholder = "text or number?")
+            dcc_input(id = "input-two",
+                      placeholder = "")
+        end
+    callback!(app, Output("input-two","placeholder"), Output("input-two","type"),
+                   Input("input-one","value")) do val1
+        if val1 in ["text", "number"]
+            return "$val1 ??", val1
+        end
+        return "invalid", nothing
+    end
+    @test length(app.callbacks) == 1
+    @test haskey(app.callbacks, Symbol("..input-two.placeholder...input-two.type.."))
+    @test app.callbacks[Symbol("..input-two.placeholder...input-two.type..")].func("text") == ("text ??", "text")
+    @test Dash.process_callback_call(app,
+            Symbol("..input-two.placeholder...input-two.type.."),
+            [(id = "input-two", property = "placeholder"),
+             (id = "input-two", property = "type")],
+            [(value = "text",)], [])[:response] == Dict("input-two" => Dict(:type => "text"))
+
+end
 @testset "callback! checks" begin
 
     app = dash()

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -143,7 +143,8 @@ end
             Symbol("..input-two.placeholder...input-two.type.."),
             [(id = "input-two", property = "placeholder"),
              (id = "input-two", property = "type")],
-            [(value = "text",)], [])[:response] == Dict("input-two" => Dict(:type => "text"))
+            [(value = "text",)], [])[:response] == Dict("input-two" => Dict(:type => "text",
+                                                                            :placeholder => "text ??"))
 
 end
 @testset "callback! checks" begin


### PR DESCRIPTION
Consider

```jl
using Dash, DashHtmlComponents, DashCoreComponents

external_stylesheets = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]

app = dash(external_stylesheets=external_stylesheets)

app.layout = html_div() do
    html_h1("Hello Dash"),
    html_div("Dash: A web application framework for Julia"),
    dcc_dropdown(id = "dd-plant",
                 placeholder = "Plant?",
                 options = [(label = x, value = x) for x in ["A", "B", "C"]],
                 searchable = true,
                 clearable = false),
    dcc_dropdown(id = "dd-device",
                 placeholder = "",
                 searchable = true,
                 clearable = false),
    dcc_graph(id = "graph")
end

callback!(app,
          Output("dd-device", "placeholder"),
          Output("dd-device", "options"),
          Input("dd-plant", "value")) do plant
    if isnothing(plant)
        return "", []
    end
    return "Device?", [(label = "$x", value = x) for x in [1, 2, 3]]
end

callback!(app,
          Output("graph", "figure"),
          Output("graph", "config"),
          Input("dd-plant", "value"),
          Input("dd-device", "value")) do plant, device
    if isnothing(plant) || isnothing(device)
        return no_update(), Dict()
    end
    return (data = [],
            layout = (title = "$plant | $device",)),
            Dict(:modeBarButtons => [["toImage"]])
end

run_server(app, "0.0.0.0", debug=true)
```

### Before this patch

![Peek 2020-12-21 18-32](https://user-images.githubusercontent.com/6675409/102831908-ecc14800-43ba-11eb-93c4-9ed020c893c3.gif)

### After this patch

![Peek 2020-12-21 18-31](https://user-images.githubusercontent.com/6675409/102831915-f21e9280-43ba-11eb-9f32-5ca0d6698ddd.gif)
