### PR TITLE
Bump compat entry for PlotlyBase.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ HTTP = "0.8.10"
 JSON = "0.21"
 JSON2 = "0.3"
 MD5 = "0.2"
-PlotlyBase = "0.3, 0.4"
+PlotlyBase = "0.3, 0.4, 0.5"
 julia = "1.2"
 
 [extras]


### PR DESCRIPTION
`PlotlyBase.jl` is currently at `0.5.1`. This just bumps the compat entry for it to `0.5` so that that minor release can be used.

(Might be worth adding https://github.com/JuliaRegistries/CompatHelper.jl to this package to automate the process somewhat. I'm happy to sort that out as well here.)