### PR TITLE
Throw error on multiple callbacks targeting same output

### DIFF
--- a/src/app/callbacks.jl
+++ b/src/app/callbacks.jl
@@ -129,7 +129,7 @@ function _callback!(func::Union{Function, ClientsideFunction, String}, app::Dash
     check_callback(func, app, deps)
 
     out_symbol = Symbol(output_string(deps))
-    haskey(app.callbacks, out_symbol) && error("Multiple callbacks can not target the same output.")
+    haskey(app.callbacks, out_symbol) && error("Multiple callbacks can not target the same output. Offending output: $(out_symbol)")
     callback_func = make_callback_func!(app, func, deps)
     push!(
         app.callbacks,

--- a/src/app/callbacks.jl
+++ b/src/app/callbacks.jl
@@ -129,6 +129,7 @@ function _callback!(func::Union{Function, ClientsideFunction, String}, app::Dash
     check_callback(func, app, deps)
 
     out_symbol = Symbol(output_string(deps))
+    haskey(app.callbacks, out_symbol) && error("Multiple callbacks can not target the same output.")
     callback_func = make_callback_func!(app, func, deps)
     push!(
         app.callbacks,

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -306,6 +306,24 @@ end
 
 end
 
+@testset "multiple callbacks targeting same output" begin
+    app = dash()
+
+    app.layout = html_div() do
+            dcc_input(id = "my-id", value="initial value", type = "text"),
+            dcc_input(id = "my-id2", value="initial value2", type = "text"),
+            html_div(id = "my-div")
+        end
+
+    callback!(app, Output("my-div","children"), Input("my-id","value")) do value
+        return value
+    end
+
+    @test_throws ErrorException callback!(app, Output("my-div","children"), Input("my-id2","value")) do value
+        return "v_$(value)"
+    end
+end
+
 @testset "empty triggered params" begin
     app = dash()
     app.layout = html_div() do

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -319,9 +319,10 @@ end
         return value
     end
 
-    @test_throws ErrorException callback!(app, Output("my-div","children"), Input("my-id2","value")) do value
+    testresult = @test_throws ErrorException callback!(app, Output("my-div","children"), Input("my-id2","value")) do value
         return "v_$(value)"
     end
+    @test testresult.value.msg == "Multiple callbacks can not target the same output. Offending output: my-div.children"
 end
 
 @testset "empty triggered params" begin


### PR DESCRIPTION
I implemented a pretty basic check and a simple testcase.
I have two questions:
- Is the test case ok?
- Should we inform the user, which is the offending output?

Closes #163.