### PR TITLE
Add Julia test workflow

### DIFF
--- a/.github/workflows/jl_test.yml
+++ b/.github/workflows/jl_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jl_version: ["1.3", "1.6", "1.8"]
+        jl_version: ["1.4", "1.6", "1.8"]
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/jl_test.yml
+++ b/.github/workflows/jl_test.yml
@@ -1,0 +1,20 @@
+name: Run Julia tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jl_version: ["1.3", "1.6", "1.8"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.jl_version }}
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          annotate: true

--- a/Project.toml
+++ b/Project.toml
@@ -36,8 +36,8 @@ JSON3 = "1.9"
 MD5 = "0.2"
 PlotlyBase = "0.8.5, 0.8.6"
 YAML = "0.4.7"
-julia = "1.3"
 Requires = "1.3"
+julia = "1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Dash for Julia
 
+[![Juila tests](https://github.com/plotly/Dash.jl/actions/workflows/jl_test.yml/badge.svg)](https://github.com/plotly/Dash.jl/actions/workflows/jl_test.yml)
 [![CircleCI](https://circleci.com/gh/plotly/Dash.jl/tree/master.svg?style=svg)](https://circleci.com/gh/plotly/Dash.jl/tree/master)
 [![GitHub](https://img.shields.io/github/license/plotly/dashR.svg?color=dark-green)](https://github.com/plotly/Dash.jl/blob/master/LICENSE)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/plotly/Dash.jl.svg?color=dark-green)](https://github.com/plotly/Dash.jl/graphs/contributors)


### PR DESCRIPTION
As discussed in https://github.com/plotly/Dash.jl/pull/175#issuecomment-1327524286, I think it would be easier to run the Julia `] test` for different Julia versions inside a Github workflow instead of inside the [`plotly/julia:ci`](https://hub.docker.com/r/plotly/julia) docker container. 

Running Julia tests inside Github workflows is fairly easy now thanks to the [julia-actions](https://github.com/julia-actions) organisation. This should make it much easier to maintain the list of tested Julia versions for Dash.jl. It's much easier to patch a yaml file than updating a docker image, right? :stuck_out_tongue: 

I'm thinking we could also drop these lines:

https://github.com/plotly/Dash.jl/blob/f0606e07d2479fd8b5be1da4a6a59656e24acfa3/.circleci/config.yml#L30-L33

https://github.com/plotly/Dash.jl/blob/f0606e07d2479fd8b5be1da4a6a59656e24acfa3/test/ci_prepare.jl#L11

and have the CircleCI workflow be used just for the integration (percy) tests. 