### PR TITLE
Release 1.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dash"
 uuid = "1b08a953-4be3-4667-9a23-3db579824955"
 authors = ["Chris Parmer <chris@plotly.com>", "Alexandr Romanenko <waralex@gmail.com>"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
Unfortunately, I'm having issue registering the new Dash.jl version.

Commenting

```
@JuliaRegistrator register
````

on https://github.com/plotly/Dash.jl/commit/e8344fb263431952a3f41a50dbf8eb201448b1f6#comments didn't do anything.

On JuliaHub, I get 

![image](https://user-images.githubusercontent.com/6675409/217382250-dd14fc87-a9fe-4e52-940a-0b3bdf1a541a.png)

So I think I might have done

```
$ git tag -a "v1.2.0"
$ git push --tags
```

that lead to https://github.com/plotly/Dash.jl/releases/tag/v1.2.0 too soon? 

The Julia General Registry wants us to register the new package version **before** git-tagging I think.

So, unfortunately here's version 1.2.1