### PR TITLE
add index by id

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/src/app/dashapp.jl
+++ b/src/app/dashapp.jl
@@ -48,10 +48,18 @@ function Base.getindex(component::DashBase.Component, id::AbstractString)
   component.id == id && return component
   hasproperty(component, :children) || return nothing
   cc = component.children
-  cc isa Union{VecChildTypes, DashBase.Component} ? cc[id] : nothing
+  cc isa Union{VecChildTypes, DashBase.Component, Vector{Any}} ? cc[id] : nothing
 end
 function Base.getindex(children::VecChildTypes, id::AbstractString)
   for element in children
+    element.id == id && return element
+    el = element[id]
+    el !== nothing && return el
+  end
+end
+function Base.getindex(children::AbstractVector, id::AbstractString)
+  for element in children
+    hasproperty(element, :id) || continue
     element.id == id && return element
     el = element[id]
     el !== nothing && return el

--- a/src/app/dashapp.jl
+++ b/src/app/dashapp.jl
@@ -41,9 +41,7 @@ mutable struct DashApp
 end
 
 const VecChildTypes = Union{NTuple{N, DashBase.Component} where {N}, Vector{<:DashBase.Component}}
-function Base.getindex(app::Dash.DashApp, id::AbstractString)
-  app.layout[id]
-end
+
 function Base.getindex(component::DashBase.Component, id::AbstractString)
   component.id == id && return component
   hasproperty(component, :children) || return nothing

--- a/src/app/dashapp.jl
+++ b/src/app/dashapp.jl
@@ -40,6 +40,24 @@ mutable struct DashApp
 
 end
 
+const VecChildTypes = Union{NTuple{N, DashBase.Component} where {N}, Vector{<:DashBase.Component}}
+function Base.getindex(app::Dash.DashApp, id::AbstractString)
+  app.layout[id]
+end
+function Base.getindex(component::DashBase.Component, id::AbstractString)
+  component.id == id && return component
+  hasproperty(component, :children) || return nothing
+  cc = component.children
+  cc isa Union{VecChildTypes, DashBase.Component} ? cc[id] : nothing
+end
+function Base.getindex(children::VecChildTypes, id::AbstractString)
+  for element in children
+    element.id == id && return element
+    el = element[id]
+    el !== nothing && return el
+  end
+end
+
 #only name, index_string and layout are available to set
 function Base.setproperty!(app::DashApp, property::Symbol, value)
     property == :index_string && return set_index_string!(app, value)

--- a/src/app/dashapp.jl
+++ b/src/app/dashapp.jl
@@ -48,18 +48,16 @@ function Base.getindex(component::DashBase.Component, id::AbstractString)
   component.id == id && return component
   hasproperty(component, :children) || return nothing
   cc = component.children
-  cc isa Union{VecChildTypes, DashBase.Component, Vector{Any}} ? cc[id] : nothing
+  return if cc isa Union{VecChildTypes, DashBase.Component}
+        cc[id]
+    elseif cc isa AbstractVector
+        identity.(filter(x->hasproperty(x, :id), cc))[id]
+    else
+        nothing
+    end
 end
 function Base.getindex(children::VecChildTypes, id::AbstractString)
   for element in children
-    element.id == id && return element
-    el = element[id]
-    el !== nothing && return el
-  end
-end
-function Base.getindex(children::AbstractVector, id::AbstractString)
-  for element in children
-    hasproperty(element, :id) || continue
     element.id == id && return element
     el = element[id]
     el !== nothing && return el

--- a/test/core.jl
+++ b/test/core.jl
@@ -212,6 +212,6 @@ end
             ]),
             html_div(id = "my-div2")
         end
-    @test app["target"].id == "target"
-    @test app["ups"] === nothing
+    @test app.layout["target"].id == "target"
+    @test app.layout["ups"] === nothing
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -213,4 +213,5 @@ end
             html_div(id = "my-div2")
         end
     @test app["target"].id == "target"
+    @test app["ups"] === nothing
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -200,3 +200,17 @@ end
     end
     @test_throws ErrorException make_handler(app)
 end
+
+@testset "Index by id" begin
+    app = dash()
+    app.layout = html_div() do
+            dcc_input(id = "my-id", value="initial value", type = "text"),
+            html_div(id = "my-div", children = [
+                html_div(),
+                "string",
+                html_div(id = "target")
+            ]),
+            html_div(id = "my-div2")
+        end
+    @test app["target"].id == "target"
+end


### PR DESCRIPTION
This adds the ability to index into `DashApp`, `Components` and collections of `Components` by id. Like
```julia
using Dash
myapp.app["my-id"]
```

This is mainly useful for testing purposes and a convenience feature.