### PR TITLE
Update docker image [final]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  percy: percy/agent@0.1.3
   browser-tools: circleci/browser-tools@1.2.4
 
 jobs:
@@ -54,12 +55,11 @@ jobs:
       - store_artifacts:
           path: /tmp/dash_artifacts
 
-      - run:
-          name: 🦔 percy finalize
-          command: npx percy finalize --all
-
 workflows:
   version: 2
   build:
     jobs:
       - test
+      - percy/finalize_all:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     working_directory: ~/dashjl
     docker:
-      - image: plotly/julia:ci
+      - image: etpinard/dashjl-tests:0.3.0
         auth:
           username: dashautomation
           password: $DASH_PAT_DOCKERHUB

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  browser-tools: circleci/browser-tools@1.2.4
 
 jobs:
 
@@ -14,6 +17,8 @@ jobs:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'True'
     steps:
       - checkout
+
+      - browser-tools/install-browser-tools
 
       - run:
           name: ℹ️  CI Context
@@ -37,8 +42,9 @@ jobs:
           command: |
             python -m venv venv
             . venv/bin/activate
+            pip install --upgrade pip wheel
             git clone --depth 1 https://github.com/plotly/dash.git -b dev dash-main
-            cd dash-main && pip install -e .[dev,testing] --progress-bar off && cd ~/dashjl
+            cd dash-main && pip install -e .[ci,dev,testing] --progress-bar off && cd ..
             export PATH=$PATH:/home/circleci/.local/bin/
             pytest --headless --nopercyfinalize --junitxml=test-reports/dashjl.xml --percy-assets=test/assets/ test/integration/
       - store_artifacts:
@@ -56,4 +62,4 @@ workflows:
   version: 2
   build:
     jobs:
-      - "test"
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,4 +57,3 @@ workflows:
   build:
     jobs:
       - "test"
-    when: false  # disable this workflow until Percy tests are functional again

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
-FROM circleci/python:3.7-stretch-node-browsers
-MAINTAINER Ryan Patrick Kyle "ryan@plotly.com"
+FROM cimg/python:3.9.9-browsers
+MAINTAINER Etienne Tétreault-Pinard "code@etpinard.xyz"
 
 RUN sudo apt-get update \
  && sudo apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
@@ -7,6 +7,6 @@ RUN sudo apt-get update \
 RUN cd /usr/local/src \
  && sudo mkdir /usr/local/src/julia \
  && sudo curl -o julia.tar.gz --location --show-error \
- https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.1-linux-x86_64.tar.gz \
+ https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.1-linux-x86_64.tar.gz \
  && sudo tar --extract --gzip --strip 1 --directory=/usr/local/src/julia --file=julia.tar.gz \
- && sudo ln -s /usr/local/src/julia/bin/julia /usr/local/bin/julia 
+ && sudo ln -s /usr/local/src/julia/bin/julia /usr/local/bin/julia

--- a/test/integration/callbacks/jl_callback_context/jlcbcx001_modified_response.jl
+++ b/test/integration/callbacks/jl_callback_context/jlcbcx001_modified_response.jl
@@ -13,9 +13,10 @@ callback!(app,
 ) do value
     cookie = HTTP.Cookie("dash_cookie", value * " - cookie")
 
-    println(String(cookie, false))
+    cookie_str = HTTP.Cookies.stringify(cookie)
+    println(cookie_str)
     http_response = callback_context().response
-    push!(http_response.headers, "Set-Cookie"=>String(cookie, false))
+    push!(http_response.headers, "Set-Cookie"=>cookie_str)
     return value * " - output"
 end
 

--- a/test/integration/callbacks/test_callback_context.py
+++ b/test/integration/callbacks/test_callback_context.py
@@ -20,7 +20,7 @@ def test_jlcbcx001_modified_response(dashjl):
     dashjl.wait_for_text_to_equal("#output", "abcd - output")
     cookie = dashjl.driver.get_cookie("dash_cookie")
     # cookie gets json encoded
-    assert cookie["value"] == 'abcd - cookie'
+    assert cookie["value"] == '"abcd - cookie"'
 
     assert not dashjl.get_logs()
 


### PR DESCRIPTION
a cleaned-up verison of https://github.com/plotly/Dash.jl/pull/205, resolves https://github.com/plotly/Dash.jl/issues/186, bringing the integration tests back to life :tada: 

Please note: the CircleCI runs now pull the [`etpinard/dashjl-tests`](https://hub.docker.com/r/etpinard/dashjl-tests) container. I'm using my personal docker hub account, since I do not have push rights to the Plotly docker hub account (and I don't need to :smile: )