### PR TITLE
Update CircleCI browser tools to `1.4.3`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   percy: percy/agent@0.1.3
-  browser-tools: circleci/browser-tools@1.2.4
+  browser-tools: circleci/browser-tools@1.4.3
 
 jobs:
 


### PR DESCRIPTION
that is, the same version used in `plotly/dash` - ref https://github.com/plotly/dash/pull/2603