### PR TITLE
Drop DashBase `0.2` compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 [compat]
 Aqua = "0.6"
 CodecZlib = "0.6, 0.7"
-DashBase = "0.2, 1"
+DashBase = "1"
 DashCoreComponents = "2.0.0"
 DashHtmlComponents = "2.0.0"
 DashTable = "5.0.0"


### PR DESCRIPTION
I think this is more correct.

Since https://github.com/plotly/Dash.jl/pull/223 removed things from Dash in https://github.com/plotly/Dash.jl/pull/223/commits/bcb5b50c4c4fc95dcfdfb19fd77b4b0b5def164e and https://github.com/plotly/Dash.jl/pull/223/commits/fb011f3a1aa4db0d12e61a3e31cd3d100d409e99 that now require DashBase v1 to work.

In other words, the upcoming Dash v1.4.0 and DashBase v0.2.0 would have missing functionality. 