### PR TITLE
Fix `convert([v], v)` dispatch for Julia 1.10

### DIFF
--- a/.github/workflows/jl_test.yml
+++ b/.github/workflows/jl_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jl_version: ["1.6", "1.8", "1.9", "~1.10.0-rc1"]
+        jl_version: ["1.6", "1.8", "1.9", "1.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/jl_test.yml
+++ b/.github/workflows/jl_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jl_version: ["1.6", "1.8", "1.9"]
+        jl_version: ["1.6", "1.8", "1.9", "~1.10.0-rc1"]
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/src/app/supporttypes.jl
+++ b/src/app/supporttypes.jl
@@ -17,7 +17,9 @@ struct TraitInput end
 struct TraitOutput end
 struct TraitState end
 
-struct Dependency{Trait, IdT <: Union{String, NamedTuple}}
+const IdTypes = Union{String,NamedTuple}
+
+struct Dependency{Trait, IdT<:IdTypes}
     id ::IdT
     property ::String
     Dependency{Trait}(id::T, property::String) where {Trait, T} = new{Trait, T}(id, property)
@@ -95,7 +97,9 @@ struct CallbackDeps
     CallbackDeps(output::Vector{<:Output}, input, state = State[]) = new(output, input, state, true)
 end
 
-Base.convert(::Type{Vector{<:T}}, v::T) where {T<:Dependency} = [v]
+Base.convert(::Type{Vector{<:Output}}, v::Output{<:IdTypes}) = [v]
+Base.convert(::Type{Vector{<:Input}}, v::Input{<:IdTypes}) = [v]
+Base.convert(::Type{Vector{<:State}}, v::State{<:IdTypes}) = [v]
 
 struct ClientsideFunction
     namespace ::String


### PR DESCRIPTION
fixes https://github.com/plotly/Dash.jl/issues/228

---

This is crucial for `CallbackDeps` instantiation

https://github.com/plotly/Dash.jl/blob/462b215b3bf4693965b4eb840fcd21550114e00c/src/app/supporttypes.jl#L88-L96

I'm not sure why the Julia <=1.9 dispatch fails in Julia 1.10.

It seems that Julia 1.10 is more strict about element types during conversion to `Vector`.

In 1.9

![image](https://github.com/plotly/Dash.jl/assets/6675409/6421daf8-cdee-44a3-acdf-68acc04c44a9)

but in 1.10

![image](https://github.com/plotly/Dash.jl/assets/6675409/7fd927b1-ccf6-4c00-ae6e-55b32aeeeba6)


Any help on this topic would be much appreciated.