### PR TITLE
Use `circleci/browser-tools@1.4.6`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   percy: percy/agent@0.1.3
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.6
 
 jobs:
 


### PR DESCRIPTION
same as for the [python version of dash](https://github.com/plotly/dash/blob/f70b3db6312c084206054cd903ee644359009486/.circleci/config.yml#L6).