### PR TITLE
Add "1.11" to list of julia versions

### DIFF
--- a/.github/workflows/jl_test.yml
+++ b/.github/workflows/jl_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jl_version: ["1.6", "1.8", "1.9", "1.10"]
+        jl_version: ["1.6", "1.8", "1.9", "1.10", "1.11"]
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
to test as part of the `jl_test` github workflow.